### PR TITLE
completed the testing for when user alreadt connected with facebook, …

### DIFF
--- a/spec/controllers/omniauth_callbacks_controller_spec.rb
+++ b/spec/controllers/omniauth_callbacks_controller_spec.rb
@@ -30,7 +30,7 @@ RSpec.fdescribe Users::OmniauthCallbacksController, type: :controller do
       end
 
       # it { @user.should_not be_nil }
-      it "@user should not be nil" do
+      it "user should not be nil" do
         expect(@user).to_not eq(nil)
       end
 
@@ -111,32 +111,38 @@ RSpec.fdescribe Users::OmniauthCallbacksController, type: :controller do
 
     end
 
-  #
-  #   context "when user already connect with facebook" do
-  #     before(:each) do
-  #       facebook_auth_hash
-  #
-  #       User.create!(name: "User", email: "user@email.com", password: "password")
-  #       user.services.create!(:provider => "facebook", :uid => "123456")
-  #       sign_in user
-  #
-  #       get :facebook
-  #     end
-  #
-  #     it "should not add new facebook service" do
-  #       user = User.where(:email => "user@email.com").first
-  #       user.should_not be_nil
-  #       fb_services = user.services.where(:provider => "facebook")
-  #       fb_services.count.should == 1
-  #     end
-  #
-  #     it { should be_user_signed_in }
-  #
-  #     it { flash[:notice].should == "Signed in successfully." }
-  #
-  #     it { response.should redirect_to tasks_path }
-  #
-    # end
-    end
 
+    context "when user already connect with facebook" do
+      before(:each) do
+        facebook_auth_hash
+
+        user = User.create!(name: "User", email: "user@email.com", password: "password")
+        user.services.create!(:provider => "facebook", :uid => "123456")
+        sign_in user
+        get :facebook
+      end
+
+      it "don't add new facebook service" do
+        user = User.where(:email => "user@email.com").first
+
+        expect(user).to_not be_nil
+
+        fb_service = user.services.where(:provider => "facebook")
+
+        expect(fb_service.count).to eq(1)
+      end
+
+      it "should still sign user in" do
+        expect be_user_signed_in
+      end
+
+      it "flashes a notice - Facebook Connected" do
+        expect(flash[:notice]).to eq("Your #{facebook_auth_hash.provider} is now Connected")
+      end
+
+      it "redirect to user profile page" do
+        expect(response).to redirect_to edit_user_registration_path
+      end
+    end
+  end
 end


### PR DESCRIPTION
…the twitter implementation follows the same path, as facebook, oauth hash has similar format, no need to repeat the tests

#New user
    when facebook email doesn't exist in the system
      user should not be nil
      should create service with facebook id
      should be signed in as the user
      redirect_to root
    when facebook email already exist in the system
      flashes an alert message
      redirects to sign in page
  #logged in user
    when user don't have facebook service
      should add facebook service to current user
      should be signed in as the user
      redirects to Profile page
      flashes a notice - Facebook Connected
    when user already connect with facebook
      don't add new facebook service
      should still sign user in
      flashes a notice - Facebook Connected
      redirect to user profile page

Finished in 0.38458 seconds (files took 4.38 seconds to load)
14 examples, 0 failures
